### PR TITLE
HevTask: Build fix for ARMv7.

### DIFF
--- a/src/arch/arm/asm.h
+++ b/src/arch/arm/asm.h
@@ -9,10 +9,17 @@
 
 #if defined(__APPLE__) || defined(__MACH__)
 
+#ifdef __arm__
+# define NESTED(symbol) \
+    .globl _##symbol; \
+    .p2align 2; \
+_##symbol:
+#else
 # define NESTED(symbol) \
     .globl _##symbol%% \
     .p2align 2%% \
 _##symbol:
+#endif
 
 # define END(symbol)
 


### PR DESCRIPTION
Separator string for 32-bit ARM is just regular semicolon, but for AArch64 it is ["%%"](https://github.com/llvm/llvm-project/blob/213a939a792f64e7bfdc684922abdf6cd1d3e388/llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCAsmInfo.cpp#L40).

